### PR TITLE
slug has no character limit of 50, toast working on copy

### DIFF
--- a/app/admin/jobs/page.tsx
+++ b/app/admin/jobs/page.tsx
@@ -46,6 +46,7 @@ import {
   EyeOff,
 } from "lucide-react";
 import { toast } from "@/hooks/use-toast";
+import { copyJobLink } from "@/lib/utils";
 
 interface Job {
   id: string;
@@ -92,6 +93,15 @@ export default function JobsPage() {
       setLoading(false);
     }
   };
+
+  // const copyJobLink = (slug: string) => {
+  //   const url = `${process.env.NEXT_PUBLIC_BASE_URL}/jobs/${slug}`;
+  //   navigator.clipboard.writeText(url);
+  //   toast({
+  //     title: "Success",
+  //     description: "Job link copied to clipboard",
+  //   });
+  // };
 
   const handleStatusToggle = async (jobId: string, currentStatus: string) => {
     const newStatus = currentStatus === "published" ? "draft" : "published";
@@ -152,14 +162,7 @@ export default function JobsPage() {
     }
   };
 
-  const copyJobLink = (slug: string) => {
-    const url = `${process.env.NEXT_PUBLIC_BASE_URL}/jobs/${slug}`;
-    navigator.clipboard.writeText(url);
-    toast({
-      title: "Success",
-      description: "Job link copied to clipboard",
-    });
-  };
+ 
 
   const filteredJobs = jobs.filter((job) => {
     const matchesSearch =

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -17,7 +17,7 @@ export const metadata = {
   openGraph: {
     title: "Rolespot – Find Your Dream Job",
     description: "A modern job board built for job seekers and employers",
-    url: "https://jobs.rolespot.space/",
+    url: "https://rolespot.space/",
     images: [{ url: "/rolespot_noBG.png", width: 1200, height: 630 }],
   },
 };

--- a/lib/actions/client-actions.tsx
+++ b/lib/actions/client-actions.tsx
@@ -1,8 +1,7 @@
 "use client";
 import { Button } from "@/components/ui/button";
 import { Copy, ExternalLink } from "lucide-react";
-import { socials } from "../utils";
-import { toast } from "sonner";
+import { copyJobLink, socials } from "../utils";
 
 export function ApplyNowButton({
   applyUrl,
@@ -31,12 +30,7 @@ export function HandleShareJobButton({ slug }: { slug: string }) {
         const shareUrl = `${process.env.NEXT_PUBLIC_BASE_URL}/jobs/${slug}`;
         navigator.clipboard
           .writeText(shareUrl)
-          .then(() => {
-            // alert("Job link copied to clipboard!");
-            toast.success("Job link copied to clipboard!", {
-              description: "You can now share this job with others.",
-            });
-          })
+          .then(() => copyJobLink(slug))
           .catch((err) => {
             console.error("Failed to copy job link: ", err);
           });

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -3,6 +3,7 @@ import { twMerge } from "tailwind-merge"
 import { prisma } from "./prisma"
 import { Prisma } from "@prisma/client";
 import { auth } from "./auth";
+import { toast } from "@/hooks/use-toast";
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
@@ -25,7 +26,7 @@ export function slugify(title: string): string {
     .replace(/[^a-z0-9\s-]/g, "")
     .trim()
     .replace(/\s+/g, "-")
-    .slice(0, 50);
+    // .slice(0, 50);
 }
 
 export async function createJobWithUniqueSlug(data: Omit<Prisma.JobCreateInput, "slug">, title: string) {
@@ -72,3 +73,12 @@ export const jobTypes = [
 export const socials = [
   "facebook", "twitter", "linkedin"
 ]
+
+export const copyJobLink = (slug: string) => {
+    const url = `${process.env.NEXT_PUBLIC_BASE_URL}/jobs/${slug}`;
+    navigator.clipboard.writeText(url);
+    toast({
+      title: "Success",
+      description: "Job link copied to clipboard",
+    });
+  };


### PR DESCRIPTION
Initially slug has 50 characters limit, which led to mid cut urls so now there is  no character limit of 50
Toast working on copy of the url globally